### PR TITLE
Feature/forward tokens and messages to firebase plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 #### Fixed
-- Firebase tokens and messages are forwarded to default Firebase plugin.
+- Firebase tokens and messages forwarding.
 
 #### Changed
 - iOS SDK version updated to 4.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-## [0.1.4] - 2020-11-19
+## Unreleased
 
+#### Fixed
+- Firebase tokens and messages are forwarded to default Firebase plugin.
+
+#### Changed
 - iOS SDK version updated to 4.6.0
 
 ## [0.1.3] - 2020-11-02

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.hypertrack.sdk.flutter">
+    <application>
+        <service
+            android:name="com.hypertrack.sdk.flutter.HyperTrackMessageForwardingService"
+            android:exported="false">
+            <intent-filter android:priority="10">
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+    </application>
 </manifest>

--- a/android/src/main/kotlin/com/hypertrack/sdk/flutter/HyperTrackMessageForwardingService.kt
+++ b/android/src/main/kotlin/com/hypertrack/sdk/flutter/HyperTrackMessageForwardingService.kt
@@ -1,0 +1,34 @@
+package com.hypertrack.sdk.flutter
+
+import android.content.Intent
+import android.util.Log
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.google.firebase.messaging.RemoteMessage
+import com.hypertrack.sdk.HyperTrackMessagingService
+
+
+class HyperTrackMessageForwardingService : HyperTrackMessagingService() {
+    override fun onMessageReceived(remoteMessage: RemoteMessage?) {
+        super.onMessageReceived(remoteMessage)
+        Log.d(TAG, "onMessageReceived: $remoteMessage")
+        try {
+            val target = Class.forName("io.flutter.plugins.firebase.messaging.FlutterFirebaseMessagingReceiver")
+            val intent = Intent(applicationContext, target)
+            intent.putExtras(remoteMessage?.toIntent()?:return)
+            sendBroadcast(intent)
+        } catch (t: Throwable) {
+            Log.d(TAG, "Can't get target to forward the message: $t")
+        }
+        
+    }
+
+    override fun onNewToken(newToken: String?) {
+        super.onNewToken(newToken)
+        Log.d(TAG, "onNewToken: $newToken")
+        val onMessageIntent = Intent("io.flutter.plugins.firebase.messaging.TOKEN")
+        onMessageIntent.putExtra("token", newToken)
+        LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(onMessageIntent)
+    }
+
+    companion object {const val TAG = "MsgForwardingService"}
+}

--- a/android/src/main/kotlin/com/hypertrack/sdk/flutter/HyperTrackMessageForwardingService.kt
+++ b/android/src/main/kotlin/com/hypertrack/sdk/flutter/HyperTrackMessageForwardingService.kt
@@ -1,33 +1,96 @@
 package com.hypertrack.sdk.flutter
 
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.util.Log
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.hypertrack.sdk.HyperTrackMessagingService
+import java.lang.reflect.Field
 
 
 class HyperTrackMessageForwardingService : HyperTrackMessagingService() {
+
+    private lateinit var services: List<FirebaseMessagingService>
+
+    override fun onCreate() {
+        super.onCreate()
+        val filterIntent = Intent("com.google.firebase.MESSAGING_EVENT")
+        val pushListenerServices = packageManager.queryIntentServices(
+                filterIntent,
+                PackageManager.GET_RESOLVED_FILTER
+        )
+        services = pushListenerServices
+                .filter { it.serviceInfo.packageName == packageName }
+                .filter { it.serviceInfo.name != javaClass.name }
+                .map {
+                    try {
+                        val serviceClass = Class.forName(it.serviceInfo.name);
+                        val serviceObject = serviceClass.newInstance();
+                        injectContext(serviceObject)
+                    } catch (e: Throwable) {
+                        Log.w(TAG, "Cannot add service ${it.serviceInfo.name} to forwarding list")
+                        null
+                    }
+                }
+                .filterIsInstance<FirebaseMessagingService>()
+        Log.d(TAG, "Created services list $services")
+
+    }
+
     override fun onMessageReceived(remoteMessage: RemoteMessage?) {
         super.onMessageReceived(remoteMessage)
-        Log.d(TAG, "onMessageReceived: $remoteMessage")
-        try {
-            val target = Class.forName("io.flutter.plugins.firebase.messaging.FlutterFirebaseMessagingReceiver")
-            val intent = Intent(applicationContext, target)
-            intent.putExtras(remoteMessage?.toIntent()?:return)
-            sendBroadcast(intent)
-        } catch (t: Throwable) {
-            Log.d(TAG, "Can't get target to forward the message: $t")
+        Log.v(TAG, "onMessageReceived: $remoteMessage")
+        services.forEach { service ->
+            try {
+                service.onMessageReceived(remoteMessage)
+            } catch (t: Throwable) {
+                Log.w(TAG, "Can't forward the message to ${service.javaClass.simpleName}")
+            }
+
         }
-        
+
     }
 
     override fun onNewToken(newToken: String?) {
         super.onNewToken(newToken)
-        Log.d(TAG, "onNewToken: $newToken")
-        val onMessageIntent = Intent("io.flutter.plugins.firebase.messaging.TOKEN")
-        onMessageIntent.putExtra("token", newToken)
-        LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(onMessageIntent)
+        Log.v(TAG, "onNewToken: $newToken")
+        services.forEach { service ->
+            try {
+                service.onNewToken(newToken)
+            } catch (t: Throwable) {
+                Log.w(TAG, "Can't forward push token to ${service.javaClass.simpleName}")
+            }
+        }
+    }
+
+
+    private fun injectContext(targetObject: Any): Any? {
+        var field: Field?
+        val fieldName = "mBase"
+        field = try {
+            targetObject.javaClass.getDeclaredField(fieldName)
+        } catch (e: NoSuchFieldException) {
+            null
+        }
+        var superClass: Class<*>? = targetObject.javaClass.superclass
+        while (field == null && superClass != null) {
+            try {
+                field = superClass.getDeclaredField(fieldName)
+            } catch (e: NoSuchFieldException) {
+                superClass = superClass.superclass
+            }
+        }
+        if (field == null) {
+            return null
+        }
+        return try {
+            field.setAccessible(true)
+            field.set(targetObject, this)
+            targetObject
+        } catch (e: Throwable) {
+            null
+        }
     }
 
     companion object {const val TAG = "MsgForwardingService"}


### PR DESCRIPTION
Resolves hypertrack/quickstart-flutter#8
Hey @bikcrum!
Could you, plz, confirm that the solution works for you as well?
We've used approach No 2 from your proposal but forward messages not to service but to receiver, as default plugin service implementation  ignores them https://github.com/FirebaseExtended/flutterfire/blob/d5476e64e58fd06a70f5d2ec728cdad288905352/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingService.java#L22