### PR TITLE
Fix swizzling not working with FlutterAppDelegate

### DIFF
--- a/ios/Classes/HyperTrackPluginSwift.swift
+++ b/ios/Classes/HyperTrackPluginSwift.swift
@@ -18,7 +18,12 @@ public class HyperTrackPluginSwift: NSObject, FlutterPlugin {
         self.availabilityEventChannel = availabilityEventChannel
         super.init()
     }
-    
+
+    public func application( _ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any],
+        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) -> Bool {
+      return false
+    }
+  
     @objc(registerWithRegistrar:)
     public static func register(with registrar: FlutterPluginRegistrar) {
         let messenger = registrar.messenger()
@@ -38,6 +43,7 @@ public class HyperTrackPluginSwift: NSObject, FlutterPlugin {
             trackingEventChannel: trackingEventChannel, errorsEventChannel: errorsEventChannel, availabilityEventChannel: availabilityEventChannel
         )
         registrar.addMethodCallDelegate(instance, channel: methodChannel)
+        registrar.addApplicationDelegate(instance)
     }
     
     @objc


### PR DESCRIPTION
[FlutterAppDelegate.mm](https://github.com/flutter/engine/blob/main/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm#L257) overrides `respondsToSelector`, and it returns `true` for the `didReceiveRemoteNotification` selector only when one of the [plugins responds to the selector](https://github.com/flutter/engine/blob/main/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm#L87). Hence the fix 🤷‍♂️

Inspired by
https://github.com/urbanairship/airship-flutter/issues/143
https://github.com/flutter/flutter/issues/52895